### PR TITLE
[feat/#1] : 게시글 조회 레포지토리 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,16 @@ repositories {
 }
 
 dependencies {
+	// Spring Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// jpa사용을 위한 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	//h2 데이터베이스 사용을 위한 의존성
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wondrous/board/Controller/HelloController.java
+++ b/src/main/java/com/wondrous/board/Controller/HelloController.java
@@ -1,0 +1,14 @@
+package com.wondrous.board.Controller;
+
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello World";
+    }
+}

--- a/src/main/java/com/wondrous/board/controller/HelloController.java
+++ b/src/main/java/com/wondrous/board/controller/HelloController.java
@@ -1,4 +1,4 @@
-package com.wondrous.board.Controller;
+package com.wondrous.board.controller;
 
 
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/wondrous/board/domain/posts/Posts.java
+++ b/src/main/java/com/wondrous/board/domain/posts/Posts.java
@@ -1,0 +1,64 @@
+package com.wondrous.board.domain.posts;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Posts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    private String author;
+
+    //빈 클래스
+    public Posts() {
+    }
+    public Posts(String title, String content, String author) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public Posts(Long id, String title, String content, String author) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    //Getter
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+
+
+    @Override
+    public String toString() {
+        return "Posts{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", author='" + author + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/wondrous/board/domain/posts/PostsRepository.java
+++ b/src/main/java/com/wondrous/board/domain/posts/PostsRepository.java
@@ -1,0 +1,13 @@
+package com.wondrous.board.domain.posts;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.List;
+
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+    @Override
+    @Lock(LockModeType.OPTIMISTIC)
+    List<Posts> findAll();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=board
+
+spring.h2.console.enabled=true

--- a/src/test/java/com/wondrous/board/domain/posts/PostsRepositoryTest.java
+++ b/src/test/java/com/wondrous/board/domain/posts/PostsRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.wondrous.board.domain.posts;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class PostsRepositoryTest {
+
+    @Autowired
+    PostsRepository postsRepository;
+
+    @PersistenceContext
+    EntityManager entityManager; // Inject the EntityManager
+
+    @AfterEach
+    @Rollback
+    void tearDown() {
+        postsRepository.deleteAll(); // Clear the repository after each test
+        entityManager.flush(); // Flush changes to the database
+        entityManager.clear(); // Clear the EntityManager to reset state
+    }
+
+    @Test
+    @Transactional
+    public void 게시글_저장_불러오기() {
+        // given
+        String title = "테스트 게시글";
+        String content = "테스트 내용";
+        String author = "DevloperKT";
+        Posts expected = new Posts(title, content, author); // Create expected post without id
+
+        // when
+        Posts actual = postsRepository.save(expected); // Save the post
+
+        // then
+        assertThat(actual).isEqualTo(expected); // Compare only the title
+    }
+
+    @Test
+    @DisplayName("모든 게시글을 조회")
+    @Transactional
+    public void posts() {
+        // given
+        Posts post1 = new Posts("테스트 게시글1", "테스트 내용1", "DevloperKT");
+        Posts post2 = new Posts("테스트 게시글2", "테스트 내용2", "DevloperGT");
+        List<Posts> expected = Arrays.asList(post1, post2);
+
+        // when
+        postsRepository.save(post1);
+        postsRepository.save(post2);
+
+        // then
+        List<Posts> actual = postsRepository.findAll();
+        assertThat(actual.toString()).isEqualTo(expected.toString());
+    }
+}


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/board_web_service/issues/1
 
# 🔑 Key Changes
Posts : 게시글 관련 정보를 저장하는 엔티티
PostsRepository : JPA를 이용하여 게시글 관련 데이터에 접근하는 인터페이스 
 
# 📢 To Reviewers
1개의 게시글 조회기능과 2개의 게시글 조회를 Repository 수준에서 테스트하여 검증