### PR TITLE
[refactor/#3] : 롬복을 사용한 생성자 전략

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 	// jpa사용을 위한 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	//롬복 추가!
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	//h2 데이터베이스 사용을 위한 의존성
 	runtimeOnly 'com.h2database:h2'
 }

--- a/src/main/java/com/wondrous/board/domain/posts/Posts.java
+++ b/src/main/java/com/wondrous/board/domain/posts/Posts.java
@@ -1,10 +1,14 @@
 package com.wondrous.board.domain.posts;
 
 import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor
+@Getter
+@ToString
 
 @Entity
 public class Posts {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -17,48 +21,10 @@ public class Posts {
 
     private String author;
 
-    //빈 클래스
-    public Posts() {
-    }
+    @Builder
     public Posts(String title, String content, String author) {
         this.title = title;
         this.content = content;
         this.author = author;
-    }
-
-    public Posts(Long id, String title, String content, String author) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.author = author;
-    }
-
-    //Getter
-    public Long getId() {
-        return id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-
-
-    @Override
-    public String toString() {
-        return "Posts{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", content='" + content + '\'' +
-                ", author='" + author + '\'' +
-                '}';
     }
 }

--- a/src/test/java/com/wondrous/board/domain/posts/PostsRepositoryTest.java
+++ b/src/test/java/com/wondrous/board/domain/posts/PostsRepositoryTest.java
@@ -11,12 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 
-import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,7 +42,11 @@ class PostsRepositoryTest {
         String title = "테스트 게시글";
         String content = "테스트 내용";
         String author = "DevloperKT";
-        Posts expected = new Posts(title, content, author); // Create expected post without id
+        Posts expected = Posts.builder()
+                .title(title)
+                .content(content)
+                .author(author)
+                .build(); // Create expected post without id
 
         // when
         Posts actual = postsRepository.save(expected); // Save the post


### PR DESCRIPTION
# ✒️ 관련 이슈번호
- feat/#3
 
# 🔑 Key Changes
- AllArgConstructor 대신 Builder 패턴 적용
 
# 📢 To Reviewers
- PostsRepositoryTest에서도 Builder 패턴을 적용해 보았습니다.
- @Data도 공부했지만 많은 기능을 한 번에 사용하는 만큼 부작용도 많아서 사용을 지양했습니다.
- @AllArgConstructor도 마찬가지로 파라미터 순서 인식문제로 인해 지양해야 함을 배웠습니다.
- 일반적으로 엔티티에 @Setter은 사용하지 않는다는 것을 배웠습니다.

