### PR TITLE
[feat/#7]: OAuth2 관련 서비스 생성

### DIFF
--- a/src/main/java/com/wondrous/board/config/oauth/SecurityConfig.java
+++ b/src/main/java/com/wondrous/board/config/oauth/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.wondrous.board.config.oauth;
 
 
 import com.wondrous.board.domain.member.entity.Role;
+import com.wondrous.board.domain.member.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/wondrous/board/domain/member/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/wondrous/board/domain/member/service/CustomOAuth2UserService.java
@@ -1,0 +1,30 @@
+package com.wondrous.board.domain.member.service;
+
+import com.wondrous.board.domain.member.dto.CustomOAuth2User;
+import com.wondrous.board.domain.member.dto.OAuth2Response;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User.getAttributes());
+
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+
+        //Naver, Google, Kakao 선택 후 강제 로그인 로직 구현
+
+        String role = "ROLE_USER";
+        //나머지 구현
+        return new CustomOAuth2User(oAuth2Response, role);
+    }
+}
+


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/board_web_service/issues/7  
  
  


# 🔑 Key Changes
- CustomOAuth2UserService: 사용자로부터 요청받은 로그인을 바탕으로 강제 회원가입 후 CustomOAuth2User을 생성





# 📢 To Reviewers
-  [ ] Oauth2Response의 구현체인 NaverResponse, GoogleResponse, KakaoResponse 추가 에정
-  [ ] ClientId, ClientSecret 발급 후 각 yml파일 추가 예정
-  [ ] 유저의 요청을 바탕으로 Naver, Google, Kakao 강제 로그인 로직 구현 예정