### PR TITLE
[perf/#1]: Custom Exception 정의하기

### DIFF
--- a/src/main/java/com/wondrous/board/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/wondrous/board/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.wondrous.board.domain.member.exception;
+
+import com.wondrous.board.global.exception.ErrorCode;
+import com.wondrous.board.global.exception.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+    public MemberNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wondrous/board/domain/posts/controller/PostsApiController.java
+++ b/src/main/java/com/wondrous/board/domain/posts/controller/PostsApiController.java
@@ -11,38 +11,39 @@ import java.util.List;
 
 
 @RequiredArgsConstructor
+@RequestMapping("/api/post")
 @RestController
 public class PostsApiController {
     private final PostsService postsService;
 
     //post 객체의 id를 Http 요청으로 받고 DB에서 조회하는 메서드
-    @GetMapping("/api/posts/{id}")
+    @GetMapping("/{id}")
     public PostsResponseDto getPostById(@PathVariable Long id) {
         return postsService.findById(id);
     }
 
     //모든 post 객체들을 조회하는 메서드
-    @GetMapping("/api/posts")
+    @GetMapping
     public List<PostsResponseDto> getAllPosts() {
         List<PostsResponseDto> posts = postsService.findAll();
         return posts;
     }
 
     //post 객체를 Http 요청으로 불러와서 DB에 저장하는 메서드
-    @PostMapping("/api/posts")
+    @PostMapping
     public Long savePost(@RequestBody PostsSaveRequestDto requestDto) {
         return postsService.save(requestDto);
     }
 
     //post 객체의 id를 Http 요청으로 불러와서 수정하고 저장해주는 메서드
-    @PostMapping("/api/posts/update/{id}")
+    @PutMapping("/{id}")
     public PostsResponseDto updatePost(@PathVariable Long id,
                         @RequestBody PostsUpdateRequestDto requestDto) {
         return postsService.update(id, requestDto);
     }
 
     //삭제
-    @PostMapping("/api/posts/delete/{id}")
+    @PostMapping("/{id}")
     public Long deletePost(@PathVariable Long id) {
         return postsService.delete(id);
     }

--- a/src/main/java/com/wondrous/board/domain/posts/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/wondrous/board/domain/posts/exception/ArticleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.wondrous.board.domain.posts.exception;
+
+
+import com.wondrous.board.global.exception.ErrorCode;
+import com.wondrous.board.global.exception.NotFoundException;
+
+public class ArticleNotFoundException extends NotFoundException {
+    public ArticleNotFoundException() {
+        super(ErrorCode.ARTICLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/wondrous/board/global/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/wondrous/board/global/exception/ArticleNotFoundException.java
@@ -1,0 +1,8 @@
+package com.wondrous.board.global.exception;
+
+
+public class ArticleNotFoundException extends NotFoundException{
+    public ArticleNotFoundException() {
+        super(ErrorCode.ARTICLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/wondrous/board/global/exception/ArticleNotFoundException.java
+++ b/src/main/java/com/wondrous/board/global/exception/ArticleNotFoundException.java
@@ -1,8 +1,0 @@
-package com.wondrous.board.global.exception;
-
-
-public class ArticleNotFoundException extends NotFoundException{
-    public ArticleNotFoundException() {
-        super(ErrorCode.ARTICLE_NOT_FOUND);
-    }
-}

--- a/src/main/java/com/wondrous/board/global/exception/BusinessException.java
+++ b/src/main/java/com/wondrous/board/global/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.wondrous.board.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
@@ -14,9 +14,12 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존제하지 않는 엔티티입니다."),
 
     //Post
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "P1", "존재하지 않는 아티클입니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "P1", "존재하지 않는 아티클입니다."),
     //Member
+    MEMER_NOT_FOUND(HttpStatus.NOT_FOUND, "M1", "존재하지 않는 멤버입니다."),
 
+    //이미지 저장
+    IMAGE_WRONG_FILE_FORMAT(HttpStatus.BAD_REQUEST, "I1", "지원하지 않는 확장자 파일입니다.");
     //Business
 
     private final String message;

--- a/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
@@ -1,20 +1,20 @@
 package com.wondrous.board.global.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-
 public enum ErrorCode {
     //Commen
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "E1", "올바르지 않은 입력값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E2", "잘못된 HTTP 메서드를 호출했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "E4", "올바르지 않은 타입입니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존제하지 않는 엔티티입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존제하지 않는 엔티티입니다."),
 
     //Post
-
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "P1", "존재하지 않는 아티클입니다.");
     //Member
 
     //Business

--- a/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
+++ b/src/main/java/com/wondrous/board/global/exception/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.wondrous.board.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+
+public enum ErrorCode {
+    //Commen
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "E1", "올바르지 않은 입력값입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E2", "잘못된 HTTP 메서드를 호출했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E3", "서버 에러가 발생했습니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "E4", "올바르지 않은 타입입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "E4", "존제하지 않는 엔티티입니다.");
+
+    //Post
+
+    //Member
+
+    //Business
+
+    private final String message;
+    private final String code;
+    private final HttpStatus httpStatus;
+
+
+    //Constructor
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.message = message;
+        this.code = code;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/wondrous/board/global/exception/ErrorResponse.java
+++ b/src/main/java/com/wondrous/board/global/exception/ErrorResponse.java
@@ -1,0 +1,32 @@
+package com.wondrous.board.global.exception;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+
+
+public class ErrorResponse {
+
+    private String message;
+    private String code;
+
+    //errorCode의 전체 enum 형태의
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.code = code.getCode();
+    }
+    //사용자 정의 message를 허용하는 생성자
+    public ErrorResponse(final ErrorCode code, final String message) {
+        this.message = message;
+        this.code = code.getCode();
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final String message) {
+        return new ErrorResponse(code, message);
+    }
+}

--- a/src/main/java/com/wondrous/board/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wondrous/board/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.wondrous.board.global.exception;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Exception을 핸들링하는 클래스.
+ * Controller까지 올라온 Exception을 처리한다.
+ */
+@Getter
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+     * HttpMessageConverter에서 등록한 HttpMessageConverter binding 못할 경우 발생한다.
+     * 주로 @requestBody, @RequestsPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+        return createErrorResponseEntity(ErrorCode.INVALID_TYPE_VALUE);
+    }
+
+    /**
+     * HttpMessageConverter에서 등록한 HttpMessageConverter binding 못할 경우 발생한다.
+     * 주로 int형으로 받아야 하는데 문자열로 받을 경우 발생
+     */
+    @ExceptionHandler(HttpMessageConversionException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageConversionException(HttpMessageConversionException e) {
+        log.error("HttpMessageConversionException", e);
+        return createErrorResponseEntity(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    /**
+     * 개발자가 정의한 사용자 Error를 처리한다.
+     * 사용자가 정의한 Exception이 만약 BusinessException을 상속하고 있다면,
+     * 해당 Handler가 처리하게 된다.
+     * 개발자가 정의한 HttpStatus에 맞게 처리한다.
+     * 개발자가 정의한 Exception은 Warn 로그를 가진다.
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException", e);
+        return createErrorResponseEntity(e.getErrorCode());
+    }
+
+
+    /**
+     * 메서드마다 return new Response<>(response, HttpStatus.status)의 반복되는 형태를 모듈화한 코드
+     */
+    private ResponseEntity<ErrorResponse> createErrorResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(
+                ErrorResponse.of(errorCode),
+                errorCode.getHttpStatus()
+        );
+    }
+
+}

--- a/src/main/java/com/wondrous/board/global/exception/NotFoundException.java
+++ b/src/main/java/com/wondrous/board/global/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.wondrous.board.global.exception;
+
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+
+    public NotFoundException() {
+        super(ErrorCode.NOT_FOUND);
+    }
+
+}

--- a/src/main/java/com/wondrous/board/global/oauth/SecurityConfig.java
+++ b/src/main/java/com/wondrous/board/global/oauth/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.wondrous.board.config.oauth;
+package com.wondrous.board.global.oauth;
 
 
 import com.wondrous.board.domain.member.entity.Role;
@@ -6,14 +6,12 @@ import com.wondrous.board.domain.member.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.DispatcherServlet;
 
 

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,52 @@
+# application.yml에 추가
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: 0238530447229a97b0049ad52043ea45
+            client-secret: wBNlrDavHs0qFWcdXmOGMFuQ9vRay0Qt
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-name: kakao
+            scope:
+              - profile_nickname
+              - profile_image
+              - email
+
+
+
+          google:
+            client-name: google
+            client-id: 341887507167-fhgmvpts1933sburmvjil6p304p24tq6.apps.googleusercontent.com
+            client-secret: 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
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope:
+              - profile
+              - email
+          naver:
+            client-name: naver
+            client-id: _YsM9TN7ACHLBV6CV1Nq
+            client-secret: yFgJUdxzvh
+            scope:
+              - name
+              - email
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: response
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+
+


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/board_web_service/issues/1
 
# 🔑 Key Changes
- 공통 API URL RequestMapping으로 묶기
- ErrorCode 정의
  - 공통 에러 코드, board 관련 에러 코드, 멤버 관련 에러 코드 정의
- Exception Handler 설계
- 도메인 package에서 각자 NotFoundError 구현체 생성
 
# 📢 To Reviewers
- [ ] 이후 DefaultResponse 구현 예정
- [ ] DefaultResponse를 상속하는 DataResponse, MessageResponse 구현 에정
- [ ] 컨트롤러에서 Custom Exception Handler 적용 에정